### PR TITLE
Send Ctrl-C before the actual command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -130,6 +130,7 @@ function run() {
     vscode.window.showInformationMessage('Running project...');
     //exec(config.commands.run, {cwd: vscode.workspace.rootPath, maxBuffer: 2048000});
     terminal.show();
+    terminal.sendText('\003'); // https://stackoverflow.com/questions/5774689/what-is-003-special-for
     terminal.sendText(config.commands.run);
 }
 


### PR DESCRIPTION
Fixes #3 

AFAIK currently there is no method to clear the current characters on vscode terminal

See https://github.com/Microsoft/vscode/blob/ab1669f8987c585c260e824584e3bf79c82fc064/src/vs/workbench/api/node/extHostTerminalService.ts

Sending a CTRL-C before the actual command seems to be the current workaround:

See https://github.com/Microsoft/vscode/issues/31262