### PR TITLE
Move build/run messages into status bar and add config options for enabling/disabling messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 .vscode-test/
-.vsix
+*.vsix

--- a/README.md
+++ b/README.md
@@ -3,17 +3,9 @@
 ![Downloads](https://img.shields.io/vscode-marketplace/d/olback.bar.svg)
 
 ## Features
-The goal with this extension is to make it easier to develop binary files. In the status bar you have the option to Build, Run and "Build and run" the project.  
-![staus bar buttons](https://raw.githubusercontent.com/olback/bar-vscode/master/images/status_bar.png)  
-The commands for building/compiling and running your project are saved in `projectRoot/.vscode/bar.conf.json` and should look like this:
-```
-{
-    "commands":{
-        "build":"your-build-command",
-        "run":"./project-exe"
-    }
-}
-```
+The goal with this extension is to make it easier to develop binary files. In the status bar you have the option to Build, Run and "Build and run" the project.
+
+![status bar buttons](https://raw.githubusercontent.com/olback/bar-vscode/master/images/status_bar.png)  
 
 ## Extension Commands
 * `Bar: Init`: Initialize the extension.
@@ -28,6 +20,29 @@ The commands for building/compiling and running your project are saved in `proje
 * Build and run: `shift+f6`
 * Build: `ctrl+shift+f6`
 * Run: `shift+f2`
+
+## Configuration
+Open the command pallete (Cmd or Ctrl+Shift+P) and run `Bar: Init` to initialize Bar and create the config file.
+
+The commands for building/compiling and running your project are saved in `projectRoot/.vscode/bar.conf.json`.
+
+```
+{
+    "commands": {
+        "build": "your-build-command",
+        "run": "./project-exe"
+    },
+    "messages": {
+        "building": true,
+        "buildSuccess": true,
+        "buildError": true,            
+        "buildErrorMessageBox": true, 
+        "run": true
+    }
+}
+```
+
+The values in the "messages" object allow you to control the kinds of status messages that will be shown. When `buildErrorMessageBox` is true, a small informational error box will also appear in the bottom right corner when the build fails.
 
 ## Bugs
 Please report any bugs or issues on [GitHub](https://github.com/olback/bar-vscode)


### PR DESCRIPTION
Hey, this is a nice extension, thanks for making it! I've been using Bar for a couple days now and wanted a way to disable the message boxes that appear when building or running.

In this pull request, I added a new status bar item to show the current status message. I then made a function `showStatusMessage` that sets this new status bar item's text to the message. This is used for the build success, build failure, and run messages. 

Next, I added a `messages` object to the config file to allow people to configure which of these messages are visible. The build failure message is able to be displayed both as a vscode error box and in the status message area. By default they are all visible.

I also created a `DEFAULT_CONFIG` object to hold the defaults to make them easy to see/change in code. It is used to create the user config file.

Lastly, I made `build` return a promise so build and run is as easy as `build().then(run)`, but this was an unrelated change that I just thought would make the code slightly nicer and remove the need for the global flag `runAfterBuild`.

Let me know if I messed anything up. I rarely submit pull requests but am trying to get into it a little more!